### PR TITLE
Add custom secret to Grafana in case when serving certificate is provided

### DIFF
--- a/assets/monitoring/grafana/v1alpha1/grafana.yaml
+++ b/assets/monitoring/grafana/v1alpha1/grafana.yaml
@@ -9,7 +9,7 @@ spec:
   ingress:
     enabled: False
   secrets:
-  - "{{ .scyllaDBMonitoringName }}-grafana-serving-certs"
+  - "{{ .servingCertSecretName }}"
   - "{{ .scyllaDBMonitoringName }}-prometheus-client-grafana"
   configMaps:
   - "{{ .scyllaDBMonitoringName }}-prometheus-serving-ca"


### PR DESCRIPTION
When custom serving certificate secret name was provided in ScyllaDBMonitoring, Grafana object was trying to use it, but it wasn't mounted as a volume. In both cases (custom and self-signed) servingCertSecretName variable points to secret name, so secret list just mentions one. 