### PR TITLE
Fetch node-exporter metrics in ServiceMonitor

### DIFF
--- a/assets/monitoring/prometheus/v1/scylladb.servicemonitor.yaml
+++ b/assets/monitoring/prometheus/v1/scylladb.servicemonitor.yaml
@@ -6,6 +6,29 @@ spec:
   selector:
     {{- .endpointsSelector | toYAML | nindent 4 }}
   endpoints:
+  - port: node-exporter
+    honorLabels: false
+    relabelings:
+    - source_labels: [ __address__ ]
+      regex: '(.*):\d+'
+      target_label: instance
+      replacement: '${1}'
+    - source_labels: [ __address__ ]
+      regex: '([^:]+)'
+      target_label: instance
+      replacement: '${1}'
+    - source_labels: [ instance ]
+      regex: '(.*)'
+      target_label: __address__
+      replacement: '${1}:9100'
+    - sourceLabels: [__meta_kubernetes_service_label_scylla_cluster]
+      regex:  '(.+)'
+      targetLabel: cluster
+      replacement: '${1}'
+    - sourceLabels: [__meta_kubernetes_pod_label_scylla_datacenter]
+      regex:  '(.+)'
+      targetLabel: dc
+      replacement: '${1}'
   - port: prometheus
     honorLabels: false
     metricRelabelings:


### PR DESCRIPTION
Scylla Pods exposes them, and Scylla Cloud requires it to show disk stats in the UI.