### PR TITLE
Add mount_point variable to overview dashboard

### DIFF
--- a/assets/monitoring/grafana/v1alpha1/overview-dashboard.configmap.yaml
+++ b/assets/monitoring/grafana/v1alpha1/overview-dashboard.configmap.yaml
@@ -4480,6 +4480,37 @@ data:
                     },
                     {
                         "allValue": null,
+                        "class": "template_variable_single",
+                        "current": {
+                            "text": "/var/lib/scylla",
+                            "value": "/var/lib/scylla"
+                        },
+                        "datasource": "prometheus",
+                        "definition": "",
+                        "error": null,
+                        "hide": 0,
+                        "includeAll": false,
+                        "label": "Mount path",
+                        "multi": false,
+                        "name": "mount_point",
+                        "options": [
+                            {
+                                "selected": true,
+                                "text": "/var/lib/scylla",
+                                "value": "/var/lib/scylla"
+                            }
+                        ],
+                        "query": "/var/lib/scylla",
+                        "skipUrlSync": false,
+                        "sort": 0,
+                        "tagValuesQuery": "",
+                        "tags": [],
+                        "tagsQuery": "",
+                        "type": "custom",
+                        "useTags": false
+                    },
+                    {
+                        "allValue": null,
                         "class": "aggregation_function",
                         "current": {
                             "tags": [],


### PR DESCRIPTION
It's used by 'Disk Size by DC' panel, one of the variables used there wasn't defined.

In original dashboard this is a query variable, but in our case, we don't want to expose other available mounts in Pod, so list is hardcoded to just scylla data dir.

